### PR TITLE
Newstoss debug and other minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ install: sklaffkom sklaffadm sklaffacct survreport sklaffwho newstoss
 	cp sklaffkom sklaffadm sklaffwho sklaffacct $(SKLAFFBIN)/
 	cp survreport $(SKLAFFBIN)/srep
 	-chown $(SKLAFFUSER) $(SKLAFFBIN)/sklaffkom $(SKLAFFBIN)/sklaffadm $(SKLAFFBIN)/sklaffwho \
-		$(SKLAFFBIN)/sklaffacct
+		$(SKLAFFBIN)/sklaffacct $(SKLAFFDIR)/log
 	-chown root   $(SKLAFFBIN)/srep
 	chmod u+s $(SKLAFFBIN)/sklaffkom $(SKLAFFBIN)/sklaffacct $(SKLAFFBIN)/sklaffwho
 	chmod og-rxw $(SKLAFFBIN)/sklaffadm

--- a/commands.c
+++ b/commands.c
@@ -1952,20 +1952,20 @@ cmd_mail(char *args)
             output("\n");
             return 0;
         }
-        if (line_ed(fname, &th, uid, 1, 0, NULL, mailrec) == NULL) {
+        if (line_ed(fname, &th, uid, 1, 0, NULL, mailrec) == NULL) {        /* Article deleted */
             output("\n%s\n\n", MSG_TEXTREM);
             return 0;
         }
         if (mailuid) {
             if (save_text(fname, &th, conf) == -1) {
-                output("\n%s\n\n", MSG_CONFMISSING);
+                output("\n%s\n\n", MSG_CONFMISSING);          /* Panic, conference missing, shouldn't happen */
                 return -1;
             }
             output("%s\n\n", MSG_SAVED);
         } else {
             snprintf(cmdline, sizeof(cmdline), "%s %s", MAILPRGM, mailrec);
             if ((pipe = (FILE *) popen(cmdline, "w")) == NULL) {
-                output("%s\n\n", MSG_NOMAIL);
+                output("%s\n\n", MSG_NOMAIL);                     /* Cannot exec mailprgm. */
                 return -1;
             }
             if ((fd = open_file(fname, 0)) == -1) {
@@ -4207,8 +4207,8 @@ cmd_upload(char *args)
 
        
 
-fprintf(stderr, "Executing: %s %s\n\n\n", UPLOADPRGM, ULOPT1);   	/* debugging */
-fprintf(stderr, "EUID: %d\n", getuid()); 			/* Debug: Check the effective user ID */
+/* fprintf(stderr, "Executing: %s %s\n\n\n", UPLOADPRGM, ULOPT1); */  	/* debugging */
+/* fprintf(stderr, "EUID: %d\n", getuid()); */			/* Debug: Check the effective user ID */
 
     char *args[] = {UPLOADPRGM, ULOPT1, NULL};  			/* Added by PL 2025-07-17 */
     execvp(UPLOADPRGM, args); 						/* Replaces execl() that was broken. PL 2025-07-17 */

--- a/edit.c
+++ b/edit.c
@@ -490,7 +490,7 @@ line_ed(char *fname, struct TEXT_HEADER * th, int edit_text, int allow_say, int 
                         if (Current_conf)
                             sprintf(newname, "%s/%d/%ld", SKLAFF_DB,
                                 Current_conf, th->comment_num);
-                        else                        
+                        else                       
 			    snprintf(newname, sizeof(newname), "%.60s/%ld", Mbox, th->comment_num); /* modified on 2025-07-12, PL */
                         fd = open_file(newname, 0);
                         buf = read_file(fd);

--- a/survey.c
+++ b/survey.c
@@ -39,7 +39,6 @@ struct RESSHOW {
 
 /* static int resshowcompare(struct RESSHOW *, struct RESSHOW *); */
 static int parse_survey_line(char *);
-/* static int input_survey_quest(char *, char *, int, int); */
 static int input_survey_quest(LINE lin, LINE reply, int qtype, int flag); /* modified on 2025-07-12, PL */
 
 int

--- a/survreport.c
+++ b/survreport.c
@@ -91,7 +91,6 @@ main(int argc, char *argv[])
         th->comment_num = num;
         th->comment_conf = 0;
         strcpy(tmp, MSG_REPORT);
-     /* strncat(tmp, th->subject, LINE_LEN - strlen(MSG_REPORT) - strlen(MSG_SUBJECT) - 4); */
         strlcat(tmp, th->subject, sizeof(tmp));  /* modified on 2025-07-13, PL */
         strcpy(th->subject, tmp);
         th->type = TYPE_TEXT;
@@ -129,9 +128,7 @@ post_survey_result(char *resultbuf, struct TEXT_HEADER * th, int conf, int ouid,
     if (conf < 0) {
         usernum = conf - (conf * 2);
         mbox_dir(usernum, home);
-     /* sprintf(conffile, "%s%s", home, MAILBOX_FILE); */
         snprintf(conffile, sizeof(conffile), "%.200s%s", home, MAILBOX_FILE); /* 2025-07-13 PL */
-     /*	sprintf(confdir, "%s/", home); */
         snprintf(confdir, sizeof(confdir), "%.200s/", home); /* 2025-07-13 PL */
         conf = 0;
     } else {
@@ -164,7 +161,6 @@ post_survey_result(char *resultbuf, struct TEXT_HEADER * th, int conf, int ouid,
         return -1L;
     }
 
- /* sprintf(textfile, "%s%ld", confdir, ce.last_text); */
     snprintf(textfile, sizeof(textfile), "%.200s%ld", confdir, ce.last_text); /* 2025-07-13 PL */
 
     if ((fdoutfile = open_file(textfile, OPEN_QUIET | OPEN_CREATE)) == -1) {

--- a/user.c
+++ b/user.c
@@ -379,7 +379,6 @@ set_from(int uid, char *value)
         }
     }
 
- /* strncpy(ae.from, value, FROM_FIELD_LEN); */
     strlcpy(ae.from, value, FROM_FIELD_LEN);  /* modified on 2025-07-12, PL */
     nbuf = replace_active(&ae, oldbuf);
     /* critical();  Shouldn't this be here? /OR 98-04-11 */


### PR DESCRIPTION
* Very important fix for detecting usenet article headers (avoiding segfault if reading newstosse'd articles with header off)
* newstoss.c : needs cleanup but now has a very verbose output to tackle tricky settings with inn
* Makefile hopefully creates the log directory with correct permissions now?
* Some empty spacing fixed as well as removal of old code replacements (when we now know that the new code works)

Please compile and report any issues. I'm working in paralell between FreeBSD and Linux and sometimes I mess things up :).

Don't forget to manually copy the "newstoss" binary to wherever you want to run it from, such as /usr/local/bin. By default it's put in /usr/local/sklaff/etc after install, which to me does not makes much sense. For the future maybe copy both mailtoss and newstoss to /usr/local/bin in the Makefile.